### PR TITLE
Update sambaNTPassword for users who have a sambaSamAccount objectclass

### DIFF
--- a/php/class.passwdmodule.php
+++ b/php/class.passwdmodule.php
@@ -135,6 +135,7 @@ class PasswdModule extends Module
 						if (in_array('sambaSamAccount', $entries[0]['objectclass'])) {
 							$nthash = strtoupper(bin2hex(mhash(MHASH_MD4, iconv("UTF-8","UTF-16LE", $passwd))));
 							$entry['sambaNTPassword'] = $nthash;
+							$entry['sambaPwdLastSet'] = strval(time());
 						}
 						ldap_modify($ldapconn, $userdn, $entry);
 						if (ldap_errno($ldapconn) === 0) {


### PR DESCRIPTION
Hi,

I have made a simple modification which updates the NT hash used by Samba, as long as the user has a sambaSamAccount objectclass. The LM hash is not changed because it is no longer used by samba, and is considered insecure.

Please review and consider including this change.

Linnea