### PR TITLE
FIX: _SESSION['password'] was superseded by EncryptionStore

### DIFF
--- a/php/class.passwdmodule.php
+++ b/php/class.passwdmodule.php
@@ -201,8 +201,19 @@ class PasswdModule extends Module
 
 		// get current session password
 		$sessionPass = $_SESSION['password'];
+		// if this plugin is used on a webapp version with EncryptionStore,
+		// $_SESSION['password'] is no longer available. User EncryptionStore
+		// in this case.
+		// EncryptionStore was introduced in webapp core somewhere after
+		// version 2.1.2, and with or before version 2.2.0.414.
+		// tested with Zarafa WebApp 2.2.1.43-199.1 running with
+		// Zarafa Server 7.2.4.29-99.1
+		if(class_exists("EncryptionStore")) {
+			$encryptionStore = EncryptionStore::getInstance();
+			$sessionPass = $encryptionStore->get("password");
+		}
 		// if user has openssl module installed
-		if (function_exists("openssl_decrypt")) {
+		else if (function_exists("openssl_decrypt")) {
 			if (version_compare(phpversion(), "5.3.3", "<")) {
 				$sessionPass = openssl_decrypt($sessionPass, "des-ede3-cbc", PASSWORD_KEY, 0);
 			} else {


### PR DESCRIPTION
Hello,

today when trying to change my password i found out, that this was no longer possible using this plugin.
The error-message given was "Current password does not match." always, despite typing in the correct password.

Further inspection revealed, that in file .../zarafa-webapp/plugins/passwd/php/class.passwdmodule.php near line 204, the variable $sessionPass always had a NULL value. The variable $_SESSION didn't have a property 'password' set.

Applying guesswork i concluded, that the zarafa-webapp code switched away from _SESSION['password'], didn't use PASSWORD_KEY / PASSWORD_IV any longer, and instead, introduced a new class EncryptionStore.
However, i wasn't able to find a changelog detailing the changes or listing with what version the change was introduced, and, whether the new EncryptionStore class was considered intended API to be used by plugins. The change was introduced somewhere after 2.1.2 and was present in 2.2.1.43-199.1, which is only a minor version change thus should be backward-compatible (which it isn't with regard to _SESSION['password']).

The fix proposed in this pull request tests for the presence of the EncryptionStore class, in order to still support older zarafa webapp version. If the class is found, it's singleton instance is used to retrieve the decrypted password. Further processing continues as before.

With kind regards,

Max-Julian Pogner